### PR TITLE
New parameter for using the fully qualified name of the function

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ batched_euclidean_distance(CudaTensor[10000, 800], CudaTensor[12000, 800]) -> to
     * `file_path` (`str`): If not `None`, writes the measurement at the end of the given file path. For thread safe file writing configure use `logger_name` instead. Default: `None`.
     * `logger_name` (`str`): If not `None`, uses the given logger to print the measurement. Can't be used in conjunction with `file_path`. Default: `None`. See [Using a logger](#using-a-logger).
     * `return_time` (`bool`): If `True`, returns the elapsed time in addition to the wrapped function's return value. Default: `False`.
-    * `out` (`dict`): If not `None`, stores the elapsed time in nanoseconds in the given dict using the function name as key. If the key already exists, adds the time to the existing value. Default: `None`. See [Storing the elapsed time in a dict](#storing-the-elapsed-time-in-a-dict).
-    * `use_qualname` (`bool`): If `True`, uses the qualified name of the function in all scenarios when the name is used. The qualified name is also used as the key to the `out` parameter. Default: `False`.
+    * `out` (`dict`): If not `None`, stores the elapsed time in nanoseconds in the given dict using the fully qualified function name as key.  If the key already exists, adds the time to the existing value. Default: `None`. See [Storing the elapsed time in a dict](#storing-the-elapsed-time-in-a-dict).
+    * `use_qualname` (`bool`): If `True`, If `True`, uses the qualified name of the function when logging the elapsed time. Default: `False`.
 
 2. `nested_timed` is similar to `timed`, however it is designed to work nicely with multiple timed functions that call each other, displaying both the total execution time and the difference after subtracting other timed functions on the same call stack. See [Nested timing decorator](#nested-timing-decorator).
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ batched_euclidean_distance(CudaTensor[10000, 800], CudaTensor[12000, 800]) -> to
     * `logger_name` (`str`): If not `None`, uses the given logger to print the measurement. Can't be used in conjunction with `file_path`. Default: `None`. See [Using a logger](#using-a-logger).
     * `return_time` (`bool`): If `True`, returns the elapsed time in addition to the wrapped function's return value. Default: `False`.
     * `out` (`dict`): If not `None`, stores the elapsed time in nanoseconds in the given dict using the function name as key. If the key already exists, adds the time to the existing value. Default: `None`. See [Storing the elapsed time in a dict](#storing-the-elapsed-time-in-a-dict).
+    * `use_qualname` (`bool`): If `True`, uses the qualified name of the function in all scenarios when the name is used. The qualified name is also used as the key to the `out` parameter. Default: `False`.
 
 2. `nested_timed` is similar to `timed`, however it is designed to work nicely with multiple timed functions that call each other, displaying both the total execution time and the difference after subtracting other timed functions on the same call stack. See [Nested timing decorator](#nested-timing-decorator).
 
@@ -280,6 +281,19 @@ numpy_operation(
     inplace=True
 )
 # numpy_operation([array([[0.74500602, 0.70666224, 0.83888559]])], [[0.74579988 0.51878032 0.06419635]], ('weights', '[0.0]'), ('inplace', 'True')) -> total time: 185300ns
+```
+
+Using the fully qualified name for timing. 
+
+```py
+from time import sleep
+from timed_decorator.simple_timed import timed
+class ClassA:
+    @timed(use_qualname=True)
+    def wait(self, x):
+        sleep(x)
+ClassA().wait(0.1)
+# ClassA.wait() -> total time: 100943000ns
 ```
 
 ### Nested timing decorator

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -99,16 +99,28 @@ class UsageTest(unittest.TestCase):
         self.assertIn(fn.__name__, logged[1])
 
     def test_ns_output(self):
-        ns = {}
+        out = {}
 
-        @timed(out=ns, stdout=False)
+        @timed(out=out, stdout=False)
         def fn():
             sleep(0.5)
 
         fn()
 
-        self.assertIsInstance(ns[fn.__name__], int)
-        self.assertGreater(ns[fn.__name__], 1 ** 9 / 2)
+        self.assertIsInstance(out[fn.__name__], int)
+        self.assertGreater(out[fn.__name__], 1 ** 9 / 2)
+
+    def test_qualname(self):
+        out = {}
+
+        class ClassA:
+            @timed(use_qualname=True, out=out)
+            def wait(self, x):
+                sleep(x)
+
+        ClassA().wait(0.1)
+        key = next(iter(out.keys()))
+        self.assertIn(ClassA.__name__, key)
 
     def test_return_time(self):
         seconds = 0.1

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -65,7 +65,7 @@ class UsageTest(unittest.TestCase):
 
         @timed(file_path=filename, stdout=False)
         def fn():
-            sleep(0.5)
+            sleep(0.1)
 
         try:
             fn()
@@ -87,34 +87,41 @@ class UsageTest(unittest.TestCase):
         logging.getLogger(logger_name).addHandler(log_handler)
 
         @timed(logger_name=logger_name, stdout=False)
-        def fn():
-            sleep(0.5)
+        def fn_1():
+            sleep(0.1)
 
-        fn()
-        fn()
+        fn_1()
+
+        @timed(logger_name=logger_name, stdout=False, use_qualname=True)
+        def fn_2():
+            sleep(0.1)
+
+        fn_2()
 
         logged = log_stream.getvalue().split('\n')[:-1]
         self.assertEqual(len(logged), 2)
-        self.assertIn(fn.__name__, logged[0])
-        self.assertIn(fn.__name__, logged[1])
+        self.assertIn(fn_1.__name__, logged[0])
+        self.assertNotIn(fn_1.__qualname__, logged[0])
+        self.assertIn(fn_2.__name__, logged[1])
+        self.assertIn(fn_2.__qualname__, logged[1])
 
     def test_ns_output(self):
         out = {}
 
         @timed(out=out, stdout=False)
         def fn():
-            sleep(0.5)
+            sleep(0.1)
 
         fn()
 
-        self.assertIsInstance(out[fn.__name__], int)
-        self.assertGreater(out[fn.__name__], 1 ** 9 / 2)
+        self.assertIsInstance(out[fn.__qualname__], int)
+        self.assertGreater(out[fn.__qualname__], 1e+8)
 
     def test_qualname(self):
         out = {}
 
         class ClassA:
-            @timed(use_qualname=True, out=out)
+            @timed(out=out)
             def wait(self, x):
                 sleep(x)
 

--- a/timed_decorator/nested_timed.py
+++ b/timed_decorator/nested_timed.py
@@ -22,7 +22,8 @@ def nested_timed(collect_gc: bool = True,
                  file_path: Union[str, None] = None,
                  logger_name: Union[str, None] = None,
                  return_time: bool = False,
-                 out: dict = None):
+                 out: dict = None,
+                 use_qualname: bool = False):
     """
     A nested timing decorator that measures the time elapsed during the function call and accounts for other decorators
     further in the call stack.
@@ -51,6 +52,8 @@ def nested_timed(collect_gc: bool = True,
             Default: `False`.
         out (dict): If not `None`, stores the elapsed time in nanoseconds in the given dict using the function name as
             key. If the key already exists, adds the time to the existing value. Default: `None`.
+        use_qualname (bool): If `True`, uses the qualified name of the function in all scenarios when the name is used.
+            The qualified name is also used as the key to the `out` parameter. Default: `False`.
     """
     gc_collect = collect if collect_gc else nop
     time_formatter = TimeFormatter(use_seconds, precision)
@@ -95,8 +98,9 @@ def nested_timed(collect_gc: bool = True,
                     nested_times[nested_level] = []
                 nested_times[nested_level].append(elapsed)
 
-            ns_out(out, fn.__name__, elapsed)
-            logger('\t' * nested_level + f'{input_formatter(fn.__name__, *args, **kwargs)} '
+            fn_name = fn.__qualname__ if use_qualname else fn.__name__
+            ns_out(out, fn_name, elapsed)
+            logger('\t' * nested_level + f'{input_formatter(fn_name, *args, **kwargs)} '
                                          f'-> total time: {time_formatter(elapsed)}, '
                                          f'own time: {time_formatter(own_time)}')
             if return_time:

--- a/timed_decorator/nested_timed.py
+++ b/timed_decorator/nested_timed.py
@@ -50,10 +50,10 @@ def nested_timed(collect_gc: bool = True,
             with `file_path`. Default: `None`.
         return_time (bool): If `True`, returns the elapsed time in addition to the wrapped function's return value.
             Default: `False`.
-        out (dict): If not `None`, stores the elapsed time in nanoseconds in the given dict using the function name as
-            key. If the key already exists, adds the time to the existing value. Default: `None`.
-        use_qualname (bool): If `True`, uses the qualified name of the function in all scenarios when the name is used.
-            The qualified name is also used as the key to the `out` parameter. Default: `False`.
+        out (dict): If not `None`, stores the elapsed time in nanoseconds in the given dict using the fully qualified
+            function name as key. If the key already exists, adds the time to the existing value. Default: `None`.
+        use_qualname (bool): If `True`, uses the qualified name of the function when logging the elapsed time. Default:
+            `False`.
     """
     gc_collect = collect if collect_gc else nop
     time_formatter = TimeFormatter(use_seconds, precision)

--- a/timed_decorator/nested_timed.py
+++ b/timed_decorator/nested_timed.py
@@ -99,7 +99,7 @@ def nested_timed(collect_gc: bool = True,
                 nested_times[nested_level].append(elapsed)
 
             fn_name = fn.__qualname__ if use_qualname else fn.__name__
-            ns_out(out, fn_name, elapsed)
+            ns_out(out, fn.__qualname__, elapsed)
             logger('\t' * nested_level + f'{input_formatter(fn_name, *args, **kwargs)} '
                                          f'-> total time: {time_formatter(elapsed)}, '
                                          f'own time: {time_formatter(own_time)}')

--- a/timed_decorator/simple_timed.py
+++ b/timed_decorator/simple_timed.py
@@ -46,10 +46,10 @@ def timed(collect_gc: bool = True,
             with `file_path`. Default: `None`.
         return_time (bool): If `True`, returns the elapsed time in addition to the wrapped function's return value.
             Default: `False`.
-        out (dict): If not `None`, stores the elapsed time in nanoseconds in the given dict using the function name as
-            key. If the key already exists, adds the time to the existing value. Default: `None`.
-        use_qualname (bool): If `True`, uses the qualified name of the function in all scenarios when the name is used.
-            The qualified name is also used as the key to the `out` parameter. Default: `False`.
+        out (dict): If not `None`, stores the elapsed time in nanoseconds in the given dict using the fully qualified
+            function name as key. If the key already exists, adds the time to the existing value. Default: `None`.
+        use_qualname (bool): If `True`, uses the qualified name of the function when logging the elapsed time. Default:
+            `False`.
     """
     gc_collect = collect if collect_gc else nop
     time_formatter = TimeFormatter(use_seconds, precision)

--- a/timed_decorator/simple_timed.py
+++ b/timed_decorator/simple_timed.py
@@ -75,7 +75,7 @@ def timed(collect_gc: bool = True,
 
             elapsed = end - start
             fn_name = fn.__qualname__ if use_qualname else fn.__name__
-            ns_out(out, fn_name, elapsed)
+            ns_out(out, fn.__qualname__, elapsed)
             logger(f'{input_formatter(fn_name, *args, **kwargs)} -> total time: {time_formatter(elapsed)}')
             if return_time:
                 return ret, elapsed

--- a/timed_decorator/simple_timed.py
+++ b/timed_decorator/simple_timed.py
@@ -19,7 +19,8 @@ def timed(collect_gc: bool = True,
           file_path: Union[str, None] = None,
           logger_name: Union[str, None] = None,
           return_time: bool = False,
-          out: dict = None):
+          out: dict = None,
+          use_qualname: bool = False):
     """
     A simple timing decorator that measures the time elapsed during the function call and prints it.
     It uses perf_counter_ns for measuring which includes time elapsed during sleep and is system-wide.
@@ -47,6 +48,8 @@ def timed(collect_gc: bool = True,
             Default: `False`.
         out (dict): If not `None`, stores the elapsed time in nanoseconds in the given dict using the function name as
             key. If the key already exists, adds the time to the existing value. Default: `None`.
+        use_qualname (bool): If `True`, uses the qualified name of the function in all scenarios when the name is used.
+            The qualified name is also used as the key to the `out` parameter. Default: `False`.
     """
     gc_collect = collect if collect_gc else nop
     time_formatter = TimeFormatter(use_seconds, precision)
@@ -71,8 +74,9 @@ def timed(collect_gc: bool = True,
                     gc.enable()
 
             elapsed = end - start
-            ns_out(out, fn.__name__, elapsed)
-            logger(f'{input_formatter(fn.__name__, *args, **kwargs)} -> total time: {time_formatter(elapsed)}')
+            fn_name = fn.__qualname__ if use_qualname else fn.__name__
+            ns_out(out, fn_name, elapsed)
+            logger(f'{input_formatter(fn_name, *args, **kwargs)} -> total time: {time_formatter(elapsed)}')
             if return_time:
                 return ret, elapsed
             return ret

--- a/timed_decorator/utils.py
+++ b/timed_decorator/utils.py
@@ -67,7 +67,6 @@ class Logger:
             logging.getLogger(self.logger_name).info(string)
 
 
-
 class InputFormatter:
     def __init__(self, show_args: bool = False, show_kwargs: bool = False, display_level: int = 1, sep: str = ', '):
         self.show_args = show_args


### PR DESCRIPTION
* The fully qualified name of the function (`__qualname__`) is used for logging when `use_qualname` is enabled.
* The `out` parameter now uses the function's fully qualified name as key.