### PR TITLE
Added new facility for registering timed decorators and using the same decorator throughout the codebase.

### DIFF
--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -5,6 +5,7 @@ from io import StringIO
 from time import sleep
 
 from tests.functions import fibonacci, recursive_fibonacci
+from timed_decorator.builder import create_timed_decorator, get_timed_decorator
 from timed_decorator.nested_timed import nested_timed
 from timed_decorator.simple_timed import timed
 from timed_decorator.utils import build_decorated_fn
@@ -140,6 +141,21 @@ class UsageTest(unittest.TestCase):
 
         self.assertIsInstance(elapsed, int)
         self.assertGreater(elapsed / 1e+9, seconds)
+
+    def test_create_timed_decorator(self):
+        create_timed_decorator('same name')
+        self.assertRaises(KeyError, create_timed_decorator, 'same name')
+        create_timed_decorator('other name')
+
+        get_timed_decorator('same name')(fibonacci)(10000)
+        get_timed_decorator('other name')(fibonacci)(10000)
+        fn = get_timed_decorator('no name')(fibonacci)  # Does not raise error if not called
+        self.assertRaises(KeyError, fn, 10000)
+
+        # Defer instantiation
+        fn = get_timed_decorator('lazy name')(fibonacci)
+        create_timed_decorator('lazy name')
+        fn(10000)
 
 
 if __name__ == '__main__':

--- a/timed_decorator/builder.py
+++ b/timed_decorator/builder.py
@@ -8,7 +8,7 @@ _timed_decorators = {}
 
 
 def create_timed_decorator(name: str,
-                           nested: bool = True,
+                           nested: bool = False,
                            collect_gc: bool = True,
                            disable_gc: bool = False,
                            use_seconds: bool = False,
@@ -31,7 +31,7 @@ def create_timed_decorator(name: str,
         name (str): The name of the timed decorator which will be instantiated using the provided arguments. Use this
             name for retrieving the timed decorator with :class:`timed_decorator.builder.get_timed_decorator`.
         nested (bool): If `True`, uses the :class:`timed_decorator.nested_timed.nested_timed` as decorator, otherwise
-            uses :class:`timed_decorator.simple_timed.timed`.
+            uses :class:`timed_decorator.simple_timed.timed`. Default: `False`.
 
     See Also:
         :class:`timed_decorator.simple_timed.timed` for the remaining parameters' documentation.

--- a/timed_decorator/builder.py
+++ b/timed_decorator/builder.py
@@ -1,0 +1,33 @@
+from typing import Union
+
+
+def create_timed_decorator(name: str,
+                           nested: bool = True,
+                           collect_gc: bool = True,
+                           disable_gc: bool = False,
+                           use_seconds: bool = False,
+                           precision: int = 9,
+                           show_args: bool = False,
+                           show_kwargs: bool = False,
+                           display_level: int = 1,
+                           sep: str = ', ',
+                           stdout: bool = True,
+                           file_path: Union[str, None] = None,
+                           logger_name: Union[str, None] = None,
+                           return_time: bool = False,
+                           out: dict = None,
+                           use_qualname: bool = False):
+    """
+    Instantiates the timed decorator with a given name. Once instantiated, the timed decorator can be retrieved with
+    :class:`timed_decorator.builder.get_timed_decorator` and used for measuring the runtime of decorated functions.
+
+    Args:
+        name (str): The name of the timed decorator which will be instantiated using the provided arguments. Use this
+            name for retrieving the timed decorator with :class:`timed_decorator.builder.get_timed_decorator`.
+        nested (bool): If `True`, uses the :class:`timed_decorator.nested_timed.nested_timed` as decorator, otherwise
+            uses :class:`timed_decorator.simple_timed.timed`.
+
+    See Also:
+        :class:`timed_decorator.simple_timed.timed` for the remaining parameters' documentation.
+    """
+    pass

--- a/timed_decorator/nested_timed.py
+++ b/timed_decorator/nested_timed.py
@@ -27,33 +27,9 @@ def nested_timed(collect_gc: bool = True,
     """
     A nested timing decorator that measures the time elapsed during the function call and accounts for other decorators
     further in the call stack.
-    It uses perf_counter_ns for measuring which includes time elapsed during sleep and is system-wide.
 
-    Args:
-        collect_gc (bool): If `True`, runs a full garbage collection before timing the wrapped function. Default:
-            `True`.
-        disable_gc (bool): If `True`, disabled garbage collection during function execution. Default: `False`.
-        use_seconds (bool): If `True`, displays the elapsed time in seconds. Default: `False`.
-        precision (int): Used in conjunction with `use_seconds`, represents the decimal points used for printing
-            seconds. Default: `9`.
-        show_args (bool): If `True`, displays the function arguments according to `display_level`. Useful when timing
-            function calls with arguments of different magnitude. Default: `False`.
-        show_kwargs (bool): If `True`, displays the keyword arguments according to `display_level`. Default: `False`.
-        display_level (int): The level of verbosity used when printing function arguments ad keyword arguments. If `0`,
-            prints the type of the parameters. If `1`, prints values for all primitive types, shapes for arrays,
-            tensors, dataframes and length for sequences. Otherwise, prints values for all parameters. Default: `1`.
-        sep (str): The separator used when printing function arguments and keyword arguments. Default: `', '`.
-        stdout (bool): If `True`, writes the elapsed time to stdout. Default: `True`.
-        file_path (str): If not `None`, writes the measurement at the end of the given file path. For thread safe
-            file writing configure use `logger_name` instead. Default: `None`.
-        logger_name (str): If not `None`, uses the given logger to print the measurement. Can't be used in conjunction
-            with `file_path`. Default: `None`.
-        return_time (bool): If `True`, returns the elapsed time in addition to the wrapped function's return value.
-            Default: `False`.
-        out (dict): If not `None`, stores the elapsed time in nanoseconds in the given dict using the fully qualified
-            function name as key. If the key already exists, adds the time to the existing value. Default: `None`.
-        use_qualname (bool): If `True`, uses the qualified name of the function when logging the elapsed time. Default:
-            `False`.
+    See Also:
+        :class:`timed_decorator.simple_timed.timed` for parameter documentation.
     """
     gc_collect = collect if collect_gc else nop
     time_formatter = TimeFormatter(use_seconds, precision)


### PR DESCRIPTION
* Updated tests and documentation.
* Maintaining the documentation in only 1 place. Removed the parameter documentation from `nested_timer` and added a redirection to `timer`. 

The new facility allows for creating a complicated timer which is also able to accumulate elapsed times from all the measured functions. It can be easily manipulated to create code statistics using client code. 